### PR TITLE
changes to 3d computation behavior

### DIFF
--- a/fs_brainPrint.py
+++ b/fs_brainPrint.py
@@ -198,7 +198,7 @@ def options_parse():
         required_executables = ['shapeDNA-tetra', 'meshfix', 'gmsh']
         for program in required_executables:
             if fs_shapeDNA.which(program) is None:
-                print '\nERROR: Cannot find ' + program + 'in $SHAPEDNA_HOME'
+                print '\nERROR: Cannot find ' + program + ' in $SHAPEDNA_HOME'
                 print   '       Make sure that this binary is in $SHAPEDNA_HOME:'
                 print   '       ' + sdnahome
                 print   '       or re-run without the --do3d flag!\n'

--- a/fs_shapeDNA.py
+++ b/fs_shapeDNA.py
@@ -11,21 +11,16 @@
 #
 
 import warnings
-warnings.filterwarnings('ignore', '.*negative int.*')
 import os
 import sys
 import shlex
 import optparse
-import logging
 import subprocess
 import tempfile
-import shutil
-import time
-import math
-import stat
 import uuid
 import errno
 
+warnings.filterwarnings('ignore', '.*negative int.*')
 os.environ['OMP_NUM_THREADS'] = '1' # setenv OMP_NUM_THREADS 1
 
 HELPTEXT = """
@@ -349,7 +344,6 @@ def options_parse():
     return options
 
 def which(program):
-    import os
     def is_exe(fpath):
         return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
 


### PR DESCRIPTION
- 3d tet-mesh computation is turned off by default, and can be turned on by using the --do3d flag (before it was on by default, and turned off with the --skip3d flag)
- column orders of structures in the output csv file are changed. 3d computations are the last 4 columns of the csv, and are omitted when the --do3d flag isn't used.  This also fixes a bug where 4 blank columns are included in the csv file if 3d computation is skipped.
